### PR TITLE
Hotfix TRI-42 -Erase an import from a deleted module that was causing a conflict.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,6 @@ app.use('/api', router);
 
 app.use(ErrorHandling);
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(documentation, { explorer: true }));
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(documentation as swaggerUi.JsonObject, { explorer: true }));
 
 export default app;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,3 @@
 import { Router } from 'express';
-import { authRouter } from '@auth';
 
 export const router = Router();
-
-router.use('/auth', authRouter);


### PR DESCRIPTION
# Pull Request

## Description
Erase an import from a deleted module that was causing a conflict add a type to docs import to avoid es lint warning
