### PR TITLE
TRI-56/Add or remove time from a ticket

### DIFF
--- a/prisma/migrations/20240319162149_remove_manual_time_modification_relationship_with_user/migration.sql
+++ b/prisma/migrations/20240319162149_remove_manual_time_modification_relationship_with_user/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userEmitterId` on the `ManualTimeModification` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ManualTimeModification" DROP CONSTRAINT "ManualTimeModification_userEmitterId_fkey";
+
+-- AlterTable
+ALTER TABLE "ManualTimeModification" DROP COLUMN "userEmitterId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,6 @@ model User {
   authoredIssues                   Issue[]                     @relation("created")
   asignedIssues                    Issue[]                     @relation("assigned")
   emittedIssueChangeLogs           IssueChangeLog[]
-  emittedManualTimeModification    ManualTimeModification[]
   OrganizationAdministrator        OrganizationAdministrator[]
 }
 
@@ -184,14 +183,12 @@ model BlockerStatusModification {
 
 model ManualTimeModification {
   id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userEmitterId    String   @db.Uuid
   issueId          String   @db.Uuid
   timeAmount       Int
   modificationDate DateTime
   reason           String
 
-  issue       Issue @relation(fields: [issueId], references: [id])
-  userEmitter User  @relation(fields: [userEmitterId], references: [id])
+  issue Issue @relation(fields: [issueId], references: [id])
 }
 
 model IssueChangeLog {

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -246,12 +246,12 @@
  *           description: The ID of the issue.
  *           schema:
  *             type: string
- *         - in: body
- *           name: body
- *           required: true
- *           description: Input data for manual time modification.
- *           schema:
- *             $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
+ *       requestBody:
+ *         required: true
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
  *       responses:
  *         '200':
  *           description: Manual time modification created successfully.
@@ -278,12 +278,12 @@
  *           description: The ID of the issue.
  *           schema:
  *             type: string
- *         - in: body
- *           name: body
- *           required: true
- *           description: Input data for manual time modification removal.
- *           schema:
- *             $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
+ *       requestBody:
+ *         required: true
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
  *       responses:
  *          '200':
  *            description: Manual time modification created successfully.

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -65,5 +65,68 @@
  *           $ref: '#/components/responses/NotFoundException'
  *         '500':
  *           $ref: '#/components/responses/InternalServerErrorException'
- *           components:
+ *   /issues/{issueId}/add-time:
+ *     post:
+ *       summary: Create manual time modification for an issue.
+ *       tags:
+ *         - "Issue"
+ *       security:
+ *         - bearerAuth: []
+ *       description: Creates a manual time modification event for adding worked time to an issue.
+ *       parameters:
+ *         - in: path
+ *           name: issueId
+ *           required: true
+ *           description: The ID of the issue.
+ *           schema:
+ *             type: string
+ *         - in: body
+ *           name: body
+ *           required: true
+ *           description: Input data for manual time modification.
+ *           schema:
+ *             $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
+ *       responses:
+ *         '200':
+ *           description: Manual time modification created successfully.
+ *         '400':
+ *           $ref: '#/components/responses/ValidationException'
+ *         '401':
+ *           $ref: '#/components/responses/UnauthorizedException'
+ *         '404':
+ *           $ref: '#/components/responses/NotFoundException'
+ *         '500':
+ *           $ref: '#/components/responses/InternalServerErrorException'
+ *   /issues/{issueId}/remove-time:
+ *     post:
+ *       summary: Creates manual time modification for an issue.
+ *       tags:
+ *         - "Issue"
+ *       security:
+ *         - bearerAuth: []
+ *       description: Creates a manual time modification event to subtract worked time from an issue.
+ *       parameters:
+ *         - in: path
+ *           name: issueId
+ *           required: true
+ *           description: The ID of the issue.
+ *           schema:
+ *             type: string
+ *         - in: body
+ *           name: body
+ *           required: true
+ *           description: Input data for manual time modification removal.
+ *           schema:
+ *             $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
+ *       responses:
+ *          '200':
+ *           description: Manual time modification created successfully.
+ *         '400':
+ *           $ref: '#/components/responses/ValidationException'
+ *         '401':
+ *           $ref: '#/components/responses/UnauthorizedException'
+ *         '404':
+ *           $ref: '#/components/responses/NotFoundException'
+ *         '500':
+ *           $ref: '#/components/responses/InternalServerErrorException'
  */

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -63,7 +63,7 @@
  *         - in: path
  *           name: issueId
  *           schema:
- *             $ref: '#/components/parameters/IssueWorkedTimeParamsDTO'
+ *             $ref: '#/components/parameters/IssueIdParamDTO'
  *           required: true
  *           description: The ID of the issue to retrieve worked seconds for
  *       responses:

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -13,7 +13,7 @@
  *         - $ref: '#/components/parameters/IssuePauseParams'
  *       responses:
  *         '200':
- *           description: "Successful operation"
+ *           description: "Timer paused succesfully"
  *           content:
  *             application/json:
  *               schema:
@@ -25,7 +25,7 @@
  *               schema:
  *                 $ref: '#/components/responses/ValidationException'
  *         '404':
- *           description: "Inconsistent data"
+ *           description: "Entity not found"
  *           content:
  *             application/json:
  *               schema:
@@ -146,7 +146,7 @@
  *           $ref: '#/components/responses/NotFoundException'
  *         '500':
  *           $ref: '#/components/responses/InternalServerErrorException'
- *   /issues/{issueId}/add-time:
+ *   /api/issue/{issueId}/add-time:
  *     post:
  *       summary: Create manual time modification for an issue.
  *       tags:
@@ -178,7 +178,7 @@
  *           $ref: '#/components/responses/NotFoundException'
  *         '500':
  *           $ref: '#/components/responses/InternalServerErrorException'
- *   /issues/{issueId}/remove-time:
+ *   /api/issue/{issueId}/remove-time:
  *     post:
  *       summary: Creates manual time modification for an issue.
  *       tags:
@@ -201,13 +201,25 @@
  *             $ref: '#/components/schemas/ManualTimeModificationRequestDTO'
  *       responses:
  *          '200':
- *           description: Manual time modification created successfully.
- *         '400':
- *           $ref: '#/components/responses/ValidationException'
- *         '401':
- *           $ref: '#/components/responses/UnauthorizedException'
- *         '404':
- *           $ref: '#/components/responses/NotFoundException'
- *         '500':
- *           $ref: '#/components/responses/InternalServerErrorException'
+ *            description: Manual time modification created successfully.
+ *          '400':
+ *            description: "Data validation error"
+ *            content:
+ *             application/json:
+ *               schema:
+ *                 $ref: '#/components/responses/ValidationException'
+ *          '401':
+ *            $ref: '#/components/responses/UnauthorizedException'
+ *          '404':
+ *            description: "Entity not found"
+ *            content:
+ *              application/json:
+ *                schema:
+ *                  $ref: '#/components/responses/NotFoundException'
+ *          '409':
+ *            description: "Inconsistent data"
+ *            content:
+ *              application/json:
+ *                schema:
+ *                  $ref: "#/components/responses/ConflictException"
  */

--- a/src/documentation/domains/issue/controller/schemas.docs.ts
+++ b/src/documentation/domains/issue/controller/schemas.docs.ts
@@ -19,4 +19,25 @@
  *         issueId:
  *           type: string
  *           description: The ID of the issue associated with the event.
+ *     ManualTimeModificationRequestDTO:
+ *       type: object
+ *       properties:
+ *         timeAmount:
+ *           type: number
+ *           format: integer
+ *           description: The amount of time to be added or subtracted, in seconds.
+ *           example: 3600
+ *         date:
+ *           type: string
+ *           format: date-time
+ *           description: The date of the manual time modification in ISO 8601 format.
+ *           example: 2024-03-19T12:00:00Z
+ *         reason:
+ *           type: string
+ *           description: The reason for the manual time modification.
+ *           example: "Meeting with client"
+ *       required:
+ *         - timeAmount
+ *         - date
+ *         - reason
  * */

--- a/src/domains/event/dto/index.ts
+++ b/src/domains/event/dto/index.ts
@@ -108,6 +108,7 @@ export class BlockerStatusModificationDTO {
 
 /**
  * Data transfer object representing a time tracking event.
+ * This one is used when the user plays or pauses the timer.
  */
 export class TimeTrackingDTO {
   /**
@@ -195,10 +196,6 @@ export class ManualTimeModificationDTO {
    */
   id: string;
   /**
-   * The ID of the user who initiated the time modification.
-   */
-  userEmitterId: string;
-  /**
    * The ID of the issue associated with the time modification.
    */
   issueId: string;
@@ -221,7 +218,6 @@ export class ManualTimeModificationDTO {
    */
   constructor(timeModification: ManualTimeModificationDTO) {
     this.id = timeModification.id;
-    this.userEmitterId = timeModification.userEmitterId;
     this.issueId = timeModification.issueId;
     this.timeAmount = timeModification.timeAmount;
     this.modificationDate = timeModification.modificationDate;

--- a/src/domains/event/repository/event.repository.impl.ts
+++ b/src/domains/event/repository/event.repository.impl.ts
@@ -3,6 +3,7 @@ import { type ChangeScalarEventInput, IssueChangeLogDTO, type BlockEventInput, B
 import type { ManualTimeModification, PrismaClient, TimeTracking } from '@prisma/client';
 import type { ITXClientDenyList } from '@prisma/client/runtime/library';
 import { Logger } from '@utils';
+import { type ManualTimeModificationEventInput } from '@domains/issue';
 
 export class EventRepositoryImpl implements EventRepository {
   constructor(private readonly db: PrismaClient | Omit<PrismaClient, ITXClientDenyList>) {}
@@ -102,5 +103,24 @@ export class EventRepositoryImpl implements EventRepository {
     });
 
     return timeTrackingEvents.map((trackingEvent: TimeTracking) => new TimeTrackingDTO(trackingEvent));
+  }
+
+  /**
+   * Creates a manual time modification event.
+   * @async
+   * @param {ManualTimeModificationEventInput} input - The input data for the manual time modification event.
+   * @returns {Promise<ManualTimeModificationDTO>} A promise that resolves to the created manual time modification DTO.
+   */
+  async createManualTimeModification(input: ManualTimeModificationEventInput): Promise<ManualTimeModificationDTO> {
+    const event = await this.db.manualTimeModification.create({
+      data: {
+        issueId: input.issueId,
+        reason: input.reason,
+        timeAmount: input.timeAmount,
+        modificationDate: input.date,
+      },
+    });
+
+    return new ManualTimeModificationDTO({ ...event });
   }
 }

--- a/src/domains/event/repository/event.repository.ts
+++ b/src/domains/event/repository/event.repository.ts
@@ -1,4 +1,5 @@
 import { type BlockerStatusModificationDTO, type BlockEventInput, type IssueChangeLogDTO, type ChangeScalarEventInput, type TimeTrackingDTO, type UpdateTimeTracking, type ManualTimeModificationDTO } from '@domains/event/dto';
+import { type ManualTimeModificationEventInput } from '@domains/issue';
 
 export interface EventRepository {
   createIssueChangeLog: (input: ChangeScalarEventInput) => Promise<IssueChangeLogDTO>;
@@ -7,4 +8,5 @@ export interface EventRepository {
   updateTimeTrackingEvent: (input: UpdateTimeTracking) => Promise<TimeTrackingDTO>;
   getIssueManualTimeModification: (issueId: string) => Promise<ManualTimeModificationDTO[]>;
   getIssueTimeTrackingEvents: (issueId: string) => Promise<TimeTrackingDTO[]>;
+  createManualTimeModification: (input: ManualTimeModificationEventInput) => Promise<ManualTimeModificationDTO>;
 }

--- a/src/domains/issue/controller/issue.controller.ts
+++ b/src/domains/issue/controller/issue.controller.ts
@@ -4,7 +4,7 @@ import HttpStatus from 'http-status';
 import { type IssueService, IssueServiceImpl } from '@domains/issue/service';
 import { type IssueRepository, IssueRepositoryImpl } from '@domains/issue/repository';
 import { type EventRepository, EventRepositoryImpl } from '@domains/event/repository';
-import { IssueWorkedTimeParamsDTO, IssuePauseParams, type WorkedTimeDTO } from '@domains/issue/dto';
+import { IssueWorkedTimeParamsDTO, IssuePauseParams, type WorkedTimeDTO, ManualTimeModificationRequestDTO } from '@domains/issue/dto';
 require('express-async-errors');
 
 export const issueRouter = Router();
@@ -27,4 +27,31 @@ issueRouter.get('/:issueId/worked-time', validateRequest(IssueWorkedTimeParamsDT
   const workedTime: WorkedTimeDTO = await issueService.getIssueWorkedSeconds(issueId);
 
   return res.status(HttpStatus.OK).json(workedTime);
+});
+
+issueRouter.post('/:issueId/add-time', validateRequest(IssuePauseParams, 'params'), validateRequest(ManualTimeModificationRequestDTO, 'body'), async (_req: Request<IssuePauseParams, any, ManualTimeModificationRequestDTO>, res: Response) => {
+  const { issueId } = _req.params;
+  const modification = _req.body;
+
+  await issueService.createManualTimeTracking({
+    ...modification,
+    issueId,
+    date: new Date(modification.date),
+  });
+
+  return res.sendStatus(HttpStatus.OK);
+});
+
+issueRouter.post('/:issueId/remove-time', validateRequest(IssuePauseParams, 'params'), validateRequest(ManualTimeModificationRequestDTO, 'body'), async (_req: Request<IssuePauseParams, any, ManualTimeModificationRequestDTO>, res: Response) => {
+  const { issueId } = _req.params;
+  const modification = _req.body;
+
+  await issueService.createManualTimeTracking({
+    ...modification,
+    issueId,
+    timeAmount: -modification.timeAmount,
+    date: new Date(modification.date),
+  });
+
+  return res.sendStatus(HttpStatus.OK);
 });

--- a/src/domains/issue/dto/index.ts
+++ b/src/domains/issue/dto/index.ts
@@ -3,7 +3,7 @@ import { IsArray, IsBoolean, IsDateString, IsDefined, IsNotEmpty, IsNumber, IsOp
 import { type LabelDTO } from '@domains/label/dto';
 import { type StageExtendedDTO } from '@domains/stage/dto';
 import { type UserIssueDTO } from '@domains/user';
-import { IsAfterOrEqualDate } from '@utils';
+import { IsTodayOrAfterToday } from '@utils';
 
 export class IssueDTO {
   id: string;
@@ -382,7 +382,7 @@ export class ManualTimeModificationRequestDTO {
   /**
    * The date of the manual time modification. Must be a date string after or equal to today.
    */
-  @IsAfterOrEqualDate(new Date(), { message: 'Date is not today or after today' })
+  @IsTodayOrAfterToday()
   @IsDateString()
   readonly date!: string;
 

--- a/src/domains/issue/dto/index.ts
+++ b/src/domains/issue/dto/index.ts
@@ -1,5 +1,6 @@
 import { type EventInput } from '@domains/event/dto';
-import { IsDefined, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsDateString, IsDefined, IsNotEmpty, IsNumber, IsPositive, IsString, IsUUID } from 'class-validator';
+import { IsAfterOrEqualDate } from '@utils';
 
 export class IssueDTO {
   id: string;
@@ -144,4 +145,58 @@ export class WorkedTimeDTO {
   constructor(workedTime: WorkedTimeDTO) {
     this.workedTime = workedTime.workedTime;
   }
+}
+
+/**
+ * Data transfer object (DTO) representing a manual time modification request.
+ * This DTO is used to validate and structure the input data for creating manual time modifications.
+ */
+export class ManualTimeModificationRequestDTO {
+  /**
+   * The amount of time to be added or subtracted. Must be a positive number.
+   */
+  @IsPositive()
+  @IsNumber()
+  timeAmount!: number;
+
+  // to transform manually into date in service
+  /**
+   * The date of the manual time modification. Must be a date string after or equal to today.
+   */
+  @IsAfterOrEqualDate(new Date(), { message: 'Date is not today or after today' })
+  @IsDateString()
+  readonly date!: string;
+
+  /**
+   * The reason for the manual time modification. Must not be empty.
+   */
+  @IsNotEmpty()
+  readonly reason!: string;
+}
+
+/**
+ * Interface representing input data for a manual time modification event.
+ *
+ * This interface defines the structure of the data required to create a manual time modification event.
+ */
+export interface ManualTimeModificationEventInput {
+  /**
+   * The ID of the issue for which the time modification is being made.
+   */
+  readonly issueId: string;
+
+  /**
+   * The amount of time to be added or subtracted. Positive if adding, negative if subtracting
+   */
+  readonly timeAmount: number;
+
+  /**
+   * The reason for the manual time modification.
+   */
+  readonly reason: string;
+
+  /**
+   * The date of the manual time modification.
+   */
+  readonly date: Date;
 }

--- a/src/domains/issue/index.ts
+++ b/src/domains/issue/index.ts
@@ -1,0 +1,4 @@
+export * from './controller';
+export * from './service';
+export * from './repository';
+export * from './dto';

--- a/src/domains/issue/service/issue.service.impl.ts
+++ b/src/domains/issue/service/issue.service.impl.ts
@@ -29,7 +29,7 @@ export class IssueServiceImpl implements IssueService {
     if (issue == null) throw new NotFoundException('issue');
 
     const { workedTime } = await this.getIssueWorkedSeconds(input.issueId);
-    if (input.timeAmount < 0 && workedTime < input.timeAmount) {
+    if (input.timeAmount < 0 && workedTime < -input.timeAmount) {
       throw new ConflictException('The time amount you are trying to substract exceeds the total worked time of the issue');
     }
 

--- a/src/domains/issue/service/issue.service.ts
+++ b/src/domains/issue/service/issue.service.ts
@@ -1,7 +1,8 @@
-import { type TimeTrackingDTO } from '@domains/event/dto';
-import { type WorkedTimeDTO } from '@domains/issue/dto';
+import { type ManualTimeModificationDTO, type TimeTrackingDTO } from '@domains/event/dto';
+import { type ManualTimeModificationEventInput, type WorkedTimeDTO } from '@domains/issue/dto';
 
 export interface IssueService {
   pauseTimer: (issueId: string) => Promise<TimeTrackingDTO>;
   getIssueWorkedSeconds: (issueId: string) => Promise<WorkedTimeDTO>;
+  createManualTimeTracking: (input: ManualTimeModificationEventInput) => Promise<ManualTimeModificationDTO>;
 }

--- a/src/utils/validation-annotations.ts
+++ b/src/utils/validation-annotations.ts
@@ -4,7 +4,7 @@ import { type OrganizationRepository, OrganizationRepositoryImpl } from '@domain
 import { type IssueProviderRepository, IssueProviderRepositoryImpl } from '@domains/issueProvider/repository';
 import { LinearClient } from '@linear/sdk';
 import { type AuthorizationRequestDTO } from '@domains/integration/dto';
-import { compareAsc, startOfDay } from 'date-fns';
+import { compareDesc, endOfDay } from 'date-fns';
 
 const organizationRepository: OrganizationRepository = new OrganizationRepositoryImpl(db);
 const issueProviderRepository: IssueProviderRepository = new IssueProviderRepositoryImpl(db);
@@ -93,7 +93,7 @@ export class IsTodayOrAfterTodayConstraint implements ValidatorConstraintInterfa
 
     const userInput = new Date(dateInput);
 
-    return userInput.toString() !== 'Invalid Date' && compareAsc(userInput, date ?? startOfDay(new Date())) > 0;
+    return userInput.toString() !== 'Invalid Date' && compareDesc(userInput, date ?? endOfDay(new Date())) > 0;
   }
 
   defaultMessage(validationArguments?: ValidationArguments): string {

--- a/src/utils/validation-annotations.ts
+++ b/src/utils/validation-annotations.ts
@@ -79,3 +79,33 @@ export function IsValidApiKey(validationOptions?: ValidationOptions) {
     });
   };
 }
+
+/**
+ * Validator constraint class for checking if a date (in form of string) is after or equal to the provided date.
+ */
+@ValidatorConstraint()
+export class IsAfterOrEqualDateConstraint implements ValidatorConstraintInterface {
+  validate(dateInput: any, args: ValidationArguments): boolean | Promise<boolean> {
+    const [date] = args.constraints;
+    const userInput = new Date(dateInput as string);
+    return typeof dateInput !== 'string' && userInput.toString() !== 'Invalid Date' && date instanceof Date && userInput.getTime() >= date.getTime();
+  }
+}
+
+/**
+ * Validates whether a date is after or equal to the provided date.
+ * @param {Date} date - The date to compare against.
+ * @param {ValidationOptions} validationOptions - Additional validation options.
+ */
+export function IsAfterOrEqualDate(date: Date, validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isAfterOrEqualDate',
+      target: object.constructor,
+      propertyName,
+      constraints: [date],
+      options: validationOptions,
+      validator: IsAfterOrEqualDateConstraint,
+    });
+  };
+}

--- a/src/utils/validation-annotations.ts
+++ b/src/utils/validation-annotations.ts
@@ -88,7 +88,7 @@ export class IsAfterOrEqualDateConstraint implements ValidatorConstraintInterfac
   validate(dateInput: any, args: ValidationArguments): boolean | Promise<boolean> {
     const [date] = args.constraints;
     const userInput = new Date(dateInput as string);
-    return typeof dateInput !== 'string' && userInput.toString() !== 'Invalid Date' && date instanceof Date && userInput.getTime() >= date.getTime();
+    return typeof dateInput === 'string' && userInput.toString() !== 'Invalid Date' && date instanceof Date && userInput.getTime() >= date.getTime();
   }
 }
 

--- a/tests/domains/issue/issue.service.impl.test.ts
+++ b/tests/domains/issue/issue.service.impl.test.ts
@@ -1,7 +1,19 @@
 import { type IssueService, IssueServiceImpl } from '@domains/issue/service';
 import { issueRepositoryMock, eventRepositoryMock, userRepositoryMock, projectRepositoryMock } from './mock';
 import { ConflictException, NotFoundException } from '@utils';
-import { mockIssueDTO, stoppedMockTimeTrackingDTO, validMockManualTimeModification, invalidMockTimeTrackingDTO, mockUserDTO, mockProjectDTO, mockIssueViewDTO, mockIssueFilterParameters, mockNotRegisteredUserDTO } from './mockData';
+import {
+  mockIssueDTO,
+  stoppedMockTimeTrackingDTO,
+  validMockManualTimeModification,
+  invalidMockTimeTrackingDTO,
+  mockUserDTO,
+  mockProjectDTO,
+  mockIssueViewDTO,
+  mockIssueFilterParameters,
+  mockNotRegisteredUserDTO,
+  mockAddManualTimeModificationEventInput,
+  mockRemoveManualTimeModificationEventInput,
+} from './mockData';
 import { type IssueViewDTO, type WorkedTimeDTO } from '@domains/issue/dto';
 
 describe('issue service tests', () => {
@@ -159,6 +171,56 @@ describe('issue service tests', () => {
       expect.assertions(2);
       await expect(issueService.getDevIssuesFilteredAndPaginated({ ...mockIssueFilterParameters, projectId: wrongProjectId })).rejects.toThrow(NotFoundException);
       await expect(issueService.getDevIssuesFilteredAndPaginated({ ...mockIssueFilterParameters, projectId: wrongProjectId })).rejects.toThrow("Not found. Couldn't find Project");
+    });
+  });
+
+  describe('add/remove time method', () => {
+    it('should create manual time modification event', async () => {
+      // given
+      const input = mockAddManualTimeModificationEventInput;
+      const workedTime = 100; // Example worked time
+
+      issueRepositoryMock.getById.mockResolvedValueOnce(mockIssueDTO);
+      const getIssueWorkedSecondsSpy = jest.spyOn(issueService, 'getIssueWorkedSeconds').mockResolvedValueOnce({ workedTime });
+      eventRepositoryMock.createManualTimeModification.mockResolvedValueOnce(validMockManualTimeModification);
+
+      // when
+      const result = await issueService.createManualTimeTracking(mockAddManualTimeModificationEventInput);
+
+      // then
+      expect(issueRepositoryMock.getById).toHaveBeenCalledWith(input.issueId);
+      expect(getIssueWorkedSecondsSpy).toHaveBeenCalledWith(input.issueId);
+      expect(eventRepositoryMock.createManualTimeModification).toHaveBeenCalledWith(input);
+      expect(result).toEqual(validMockManualTimeModification);
+    });
+
+    it('should throw NotFoundException if issue not found', async () => {
+      // given
+      const input = mockAddManualTimeModificationEventInput;
+      issueRepositoryMock.getById.mockResolvedValueOnce(null);
+
+      // when
+      const result = issueService.createManualTimeTracking(mockAddManualTimeModificationEventInput);
+
+      // then
+      await expect(result).rejects.toThrow(NotFoundException);
+      expect(issueRepositoryMock.getById).toHaveBeenCalledWith(input.issueId);
+    });
+
+    it('should throw ConflictException if subtracting time exceeds total worked time', async () => {
+      // given
+      const input = mockRemoveManualTimeModificationEventInput;
+      const workedTime = 100; // Example worked time
+      issueRepositoryMock.getById.mockResolvedValueOnce(mockIssueDTO);
+      const getIssueWorkedSecondsSpy = jest.spyOn(issueService, 'getIssueWorkedSeconds').mockResolvedValueOnce({ workedTime });
+
+      // when
+      const result = issueService.createManualTimeTracking(input);
+
+      // then
+      await expect(result).rejects.toThrow(ConflictException);
+      expect(issueRepositoryMock.getById).toHaveBeenCalledWith(input.issueId);
+      expect(getIssueWorkedSecondsSpy).toHaveBeenCalledWith(input.issueId);
     });
   });
 });

--- a/tests/domains/issue/mockData.ts
+++ b/tests/domains/issue/mockData.ts
@@ -1,4 +1,4 @@
-import { type IssueDTO, type IssueViewDTO, type Priority } from '@domains/issue/dto';
+import { type IssueDTO, type IssueViewDTO, type ManualTimeModificationEventInput, type Priority } from '@domains/issue/dto';
 import { type ManualTimeModificationDTO, type TimeTrackingDTO } from '@domains/event/dto';
 import { type UserDTO } from '@domains/user';
 import { type ProjectDTO } from '@domains/project/dto';
@@ -43,7 +43,6 @@ export const stoppedMockTimeTrackingDTO: TimeTrackingDTO = {
 
 export const validMockManualTimeModification: ManualTimeModificationDTO = {
   id: '2bdcfe9c-80ff-43af-9f4d-438019c94e4d',
-  userEmitterId: 'd27608ce-bf6c-4806-8e98-200e6c2cb29a',
   issueId: 'issue789',
   timeAmount: 10,
   modificationDate: new Date(),
@@ -52,7 +51,6 @@ export const validMockManualTimeModification: ManualTimeModificationDTO = {
 
 export const negativeMockManualTimeModification: ManualTimeModificationDTO = {
   id: '2bdcfe9c-80ff-43af-9f4d-438019c94e4d',
-  userEmitterId: 'd27608ce-bf6c-4806-8e98-200e6c2cb29a',
   issueId: 'issue789',
   timeAmount: -7300,
   modificationDate: new Date(),
@@ -121,4 +119,18 @@ export const mockIssueFilterParameters = {
   isOutOfEstimation: false,
   labelIds: undefined,
   cursor: undefined,
+};
+
+export const mockAddManualTimeModificationEventInput: ManualTimeModificationEventInput = {
+  issueId: 'ABC123',
+  timeAmount: 3600, // Adding 1 hour (in seconds)
+  reason: 'Meeting with client',
+  date: new Date('2024-03-19T12:00:00Z'),
+};
+
+export const mockRemoveManualTimeModificationEventInput: ManualTimeModificationEventInput = {
+  issueId: 'ABC123',
+  timeAmount: -3600, // Removing 1 hour (in seconds)
+  reason: 'Meeting with client',
+  date: new Date('2024-03-19T12:00:00Z'),
 };

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -2,7 +2,7 @@ import { type Request, type Response } from 'express';
 import { validateRequest, validateUserIsProjectManager, ValidationException, userProjectRoleRepository, roleRepository, ForbiddenException, NotFoundException } from '@utils';
 import { IsString, IsNumber } from 'class-validator';
 import { mockDevRoleDTO, mockPMRoleDTO, mockUserProjectRoleDTO } from '../domains/issue/mockData';
-import { type UserProjectParamsDTO } from '@domains/issue/dto';
+import { ManualTimeModificationRequestDTO, type UserProjectParamsDTO } from '@domains/issue/dto';
 
 class TargetClass {
   @IsString()
@@ -55,6 +55,50 @@ describe('validations tests', () => {
     const next = jest.fn();
 
     await expect(validateRequest(ExtendedTargetClass, 'body')(req, res, next)).rejects.toThrow(ValidationException);
+    expect(next).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('ManualTimeModificationRequestDTO validation tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Should successfully validate DTO', async () => {
+    const date = new Date().toISOString();
+    const req = {
+      body: {
+        timeAmount: 10,
+        date, // Use today's date
+        reason: 'Testing',
+      },
+    } as unknown as Request;
+
+    const res = {} as unknown as Response;
+    const next = jest.fn();
+
+    await validateRequest(ManualTimeModificationRequestDTO, 'body')(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.body).toBeInstanceOf(ManualTimeModificationRequestDTO);
+    expect(req.body.timeAmount).toBe(10);
+    expect(req.body.date).toBe(date);
+    expect(req.body.reason).toBe('Testing');
+  });
+
+  it('Should throw exception when validating DTO with invalid data', async () => {
+    const req = {
+      body: {
+        timeAmount: -10, // Negative time amount
+        date: 'invalid date', // Invalid date format
+        reason: '', // Empty reason
+      },
+    } as unknown as Request;
+
+    const res = {} as unknown as Response;
+    const next = jest.fn();
+
+    await expect(validateRequest(ManualTimeModificationRequestDTO, 'body')(req, res, next)).rejects.toThrow(ValidationException);
     expect(next).toHaveBeenCalledTimes(0);
   });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -107,7 +107,7 @@ describe('ManualTimeModificationRequestDTO validation tests', () => {
     const req = {
       body: {
         timeAmount: -10, // Negative time amount
-        date: subDays(new Date(), 1), // Invalid date
+        date: subDays(new Date(), 1), // Today's date minus 1 day
         reason: '', // Empty reason
       },
     } as unknown as Request;

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -3,6 +3,7 @@ import { validateRequest, validateUserIsProjectManager, ValidationException, use
 import { IsString, IsNumber } from 'class-validator';
 import { mockDevRoleDTO, mockPMRoleDTO, mockUserProjectRoleDTO } from '../domains/issue/mockData';
 import { ManualTimeModificationRequestDTO, type UserProjectParamsDTO } from '@domains/issue/dto';
+import { subDays } from 'date-fns';
 
 class TargetClass {
   @IsString()
@@ -91,6 +92,22 @@ describe('ManualTimeModificationRequestDTO validation tests', () => {
       body: {
         timeAmount: -10, // Negative time amount
         date: 'invalid date', // Invalid date format
+        reason: '', // Empty reason
+      },
+    } as unknown as Request;
+
+    const res = {} as unknown as Response;
+    const next = jest.fn();
+
+    await expect(validateRequest(ManualTimeModificationRequestDTO, 'body')(req, res, next)).rejects.toThrow(ValidationException);
+    expect(next).toHaveBeenCalledTimes(0);
+  });
+
+  it('Should throw exception when validating DTO with date before today', async () => {
+    const req = {
+      body: {
+        timeAmount: -10, // Negative time amount
+        date: subDays(new Date(), 1), // Invalid date
         reason: '', // Empty reason
       },
     } as unknown as Request;

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -3,7 +3,7 @@ import { validateRequest, validateUserIsProjectManager, ValidationException, use
 import { IsString, IsNumber } from 'class-validator';
 import { mockDevRoleDTO, mockPMRoleDTO, mockUserProjectRoleDTO } from '../domains/issue/mockData';
 import { ManualTimeModificationRequestDTO, type UserProjectParamsDTO } from '@domains/issue/dto';
-import { subDays } from 'date-fns';
+import { addDays } from 'date-fns';
 
 class TargetClass {
   @IsString()
@@ -107,7 +107,7 @@ describe('ManualTimeModificationRequestDTO validation tests', () => {
     const req = {
       body: {
         timeAmount: -10, // Negative time amount
-        date: subDays(new Date(), 1), // Today's date minus 1 day
+        date: addDays(new Date(), 1), // Today's date minus 1 day
         reason: '', // Empty reason
       },
     } as unknown as Request;


### PR DESCRIPTION
# Pull Request

## Description
Add endpoints for adding or removing time from a ticket/issue. It can happen if you forgot to pause the timer, for example. Separate endpoint are added for each action.

## Ticket Link
[TRI-56](https://linear.app/tricker-sirius/issue/TRI-56/add-time-remove-time-from-a-ticket)

## Steps to Reproduce
1. Run `prisma generate`
2. Run `docker compose up`
3. Check Swagger documentation for [adding endpoint](http://localhost:8080/api-docs/#/Issue/post_api_issue__issueId__add_time) and [removing endpoint](http://localhost:8080/api-docs/#/Issue/post_api_issue__issueId__remove_time)
4. Test the endpoint with Postman or Swagger.
