### PR TITLE
TRI-143/Implement resume ticket method

### DIFF
--- a/prisma/migrations/20240320073722_unique_combination_stage_id_and_project_id_for_project_stage/migration.sql
+++ b/prisma/migrations/20240320073722_unique_combination_stage_id_and_project_id_for_project_stage/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[stageId,projectId]` on the table `ProjectStage` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectStage_stageId_projectId_key" ON "ProjectStage"("stageId", "projectId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -219,6 +219,8 @@ model ProjectStage {
 
   project Project @relation(fields: [projectId], references: [id])
   stage   Stage   @relation(fields: [stageId], references: [id])
+
+  @@unique([stageId, projectId])
 }
 
 model ProjectLabel {

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -1,9 +1,35 @@
 /**
  * @swagger
  * paths:
+ *   /api/issue/{issueId}/resume:
+ *     get:
+ *       summary: Resume timer for an issue
+ *       tags:
+ *         - Issue
+ *       description: Resume the timer for a specific issue.
+ *       parameters:
+ *         - name: issueId
+ *           in: path
+ *           required: true
+ *           description: The ID of the issue to resume the timer for.
+ *           schema:
+ *             type: string
+ *       responses:
+ *         '200':
+ *           description: Successful operation
+ *           content:
+ *             application/json:
+ *               schema:
+ *                 $ref: '#/components/schemas/TimeTrackingDTO'
+ *         '400':
+ *           $ref: '#/components/responses/ValidationException'
+ *         '404':
+ *           $ref: '#/components/responses/NotFoundException'
+ *         '409':
+ *           $ref: '#/components/responses/ConflictException'
  *   /api/issue/{issueId}/pause:
  *     get:
- *       summary: Pause Timer for an Issue
+ *       summary: Pause timer for an issue
  *       tags:
  *         - Issue
  *       description: Pause the timer for a specific issue.
@@ -17,25 +43,13 @@
  *           content:
  *             application/json:
  *               schema:
- *                 $ref: '#/components/schemas/TimeTrackingEventDTO'
+ *                 $ref: '#/components/schemas/TimeTrackingDTO'
  *         '400':
- *           description: "Data validation error"
- *           content:
- *             application/json:
- *               schema:
- *                 $ref: '#/components/responses/ValidationException'
+ *           $ref: '#/components/responses/ValidationException'
  *         '404':
- *           description: "Inconsistent data"
- *           content:
- *             application/json:
- *               schema:
- *                 $ref: '#/components/responses/NotFoundException'
+ *           $ref: '#/components/responses/NotFoundException'
  *         '409':
- *           description: "Inconsistent data"
- *           content:
- *             application/json:
- *               schema:
- *                 $ref: "#/components/responses/ConflictException"
+ *           $ref: '#/components/responses/ConflictException'
  *   /api/issue/{issueId}/worked-time:
  *     get:
  *       summary: Retrieve worked seconds for a specific issue.

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -2,7 +2,7 @@
  * @swagger
  * paths:
  *   /api/issue/{issueId}/resume:
- *     get:
+ *     post:
  *       summary: Resume timer for an issue
  *       tags:
  *         - Issue
@@ -17,7 +17,7 @@
  *           schema:
  *             type: string
  *       responses:
- *         '200':
+ *         '201':
  *           description: Successful operation
  *           content:
  *             application/json:

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -30,7 +30,7 @@
  *         '409':
  *           $ref: '#/components/responses/ConflictException'
  *   /api/issue/{issueId}/pause:
- *     get:
+ *     post:
  *       summary: Pause timer for an issue
  *       tags:
  *         - Issue
@@ -40,7 +40,7 @@
  *       parameters:
  *         - $ref: '#/components/parameters/IssuePauseParams'
  *       responses:
- *         '200':
+ *         '201':
  *           description: "Successful operation"
  *           content:
  *             application/json:

--- a/src/documentation/domains/issue/controller/issue.controller.docs.ts
+++ b/src/documentation/domains/issue/controller/issue.controller.docs.ts
@@ -6,6 +6,8 @@
  *       summary: Resume timer for an issue
  *       tags:
  *         - Issue
+ *       security:
+ *         - bearerAuth: []
  *       description: Resume the timer for a specific issue.
  *       parameters:
  *         - name: issueId

--- a/src/documentation/domains/issue/controller/schemas.docs.ts
+++ b/src/documentation/domains/issue/controller/schemas.docs.ts
@@ -2,23 +2,29 @@
  * @swagger
  * components:
  *   schemas:
- *     TimeTrackingEventDTO:
- *       type: object
- *       properties:
- *         id:
- *           type: string
- *           description: The ID of the event.
- *         startTime:
- *           type: string
- *           format: date-time
- *           description: The start time of the event.
- *         endTime:
- *           type: string
- *           format: date-time
- *           description: The end time of the event.
- *         issueId:
- *           type: string
- *           description: The ID of the issue associated with the event.
+ *     TimeTrackingDTO:
+ *        type: object
+ *        properties:
+ *          id:
+ *            type: string
+ *            description: The ID of the time tracking event.
+ *          issueId:
+ *            type: string
+ *            description: The ID of the issue associated with the event.
+ *          startTime:
+ *            type: string
+ *            format: date-time
+ *            description: The start time of the event.
+ *          endTime:
+ *            type: string
+ *            format: date-time
+ *            nullable: true
+ *            description: The end time of the event, or null if not ended yet.
+ *        example:
+ *          id: "5ebe2152-2f9b-492f-874c-c77ccb1efe20"
+ *          issueId: "648b2997-b731-468d-bce7-d213d3f7da93"
+ *          startTime: "2024-03-19T12:00:00Z"
+ *          endTime: null
  *
  *     DevOptionalIssueFiltersDTO:
  *       type: object

--- a/src/domains/event/repository/event.repository.impl.ts
+++ b/src/domains/event/repository/event.repository.impl.ts
@@ -103,4 +103,15 @@ export class EventRepositoryImpl implements EventRepository {
 
     return timeTrackingEvents.map((trackingEvent: TimeTracking) => new TimeTrackingDTO(trackingEvent));
   }
+
+  async createTimeTrackingEvent(issueId: string): Promise<TimeTrackingDTO> {
+    const event = await this.db.timeTracking.create({
+      data: {
+        issueId,
+        startTime: new Date(),
+      },
+    });
+
+    return new TimeTrackingDTO(event);
+  }
 }

--- a/src/domains/event/repository/event.repository.ts
+++ b/src/domains/event/repository/event.repository.ts
@@ -4,6 +4,7 @@ export interface EventRepository {
   createIssueChangeLog: (input: ChangeScalarEventInput) => Promise<IssueChangeLogDTO>;
   createIssueBlockEvent: (input: BlockEventInput) => Promise<BlockerStatusModificationDTO>;
   getLastTimeTrackingEvent: (issueId: string) => Promise<TimeTrackingDTO | null>;
+  createTimeTrackingEvent: (issueId: string) => Promise<TimeTrackingDTO>;
   updateTimeTrackingEvent: (input: UpdateTimeTracking) => Promise<TimeTrackingDTO>;
   getIssueManualTimeModification: (issueId: string) => Promise<ManualTimeModificationDTO[]>;
   getIssueTimeTrackingEvents: (issueId: string) => Promise<TimeTrackingDTO[]>;

--- a/src/domains/issue/controller/issue.controller.ts
+++ b/src/domains/issue/controller/issue.controller.ts
@@ -36,12 +36,12 @@ issueRouter.get('/:issueId/pause', validateRequest(IssuePauseParams, 'params'), 
   return res.status(HttpStatus.OK).json(event);
 });
 
-issueRouter.get('/:issueId/resume', async (_req: Request<IssuePauseParams>, res: Response) => {
+issueRouter.post('/:issueId/resume', async (_req: Request<IssuePauseParams>, res: Response) => {
   const { issueId } = _req.params;
 
   const event = await issueService.resumeTimer(issueId);
 
-  return res.status(HttpStatus.OK).json(event);
+  return res.status(HttpStatus.CREATED).json(event);
 });
 
 issueRouter.get('/:issueId/worked-time', validateRequest(IssueWorkedTimeParamsDTO, 'params'), async (req: Request<IssueWorkedTimeParamsDTO>, res: Response): Promise<Response<number>> => {

--- a/src/domains/issue/controller/issue.controller.ts
+++ b/src/domains/issue/controller/issue.controller.ts
@@ -7,6 +7,7 @@ import { type EventRepository, EventRepositoryImpl } from '@domains/event/reposi
 import { IssueWorkedTimeParamsDTO, IssuePauseParams, type WorkedTimeDTO, UserProjectParamsDTO, type IssueViewDTO, DevOptionalIssueFiltersDTO } from '@domains/issue/dto';
 import { type UserRepository, UserRepositoryImpl } from '@domains/user';
 import { type ProjectRepository, ProjectRepositoryImpl } from '@domains/project/repository';
+import { type ProjectStageRepository, ProjectStageRepositoryImpl } from '@domains/projectStage/repository';
 require('express-async-errors');
 
 export const issueRouter = Router();
@@ -15,7 +16,8 @@ const issueRepo: IssueRepository = new IssueRepositoryImpl(db);
 const eventRepo: EventRepository = new EventRepositoryImpl(db);
 const userRepo: UserRepository = new UserRepositoryImpl(db);
 const projectRepo: ProjectRepository = new ProjectRepositoryImpl(db);
-const issueService: IssueService = new IssueServiceImpl(issueRepo, eventRepo, userRepo, projectRepo);
+const projectStageRepo: ProjectStageRepository = new ProjectStageRepositoryImpl(db);
+const issueService: IssueService = new IssueServiceImpl(issueRepo, eventRepo, userRepo, projectRepo, projectStageRepo);
 
 issueRouter.post('/dev/:userId/project/:projectId', validateRequest(UserProjectParamsDTO, 'params'), validateRequest(DevOptionalIssueFiltersDTO, 'body'), async (req: Request<UserProjectParamsDTO, any, DevOptionalIssueFiltersDTO>, res: Response) => {
   const { userId, projectId } = req.params;
@@ -30,6 +32,14 @@ issueRouter.get('/:issueId/pause', validateRequest(IssuePauseParams, 'params'), 
   const { issueId } = _req.params;
 
   const event = await issueService.pauseTimer(issueId);
+
+  return res.status(HttpStatus.OK).json(event);
+});
+
+issueRouter.get('/:issueId/resume', async (_req: Request<IssuePauseParams>, res: Response) => {
+  const { issueId } = _req.params;
+
+  const event = await issueService.resumeTimer(issueId);
 
   return res.status(HttpStatus.OK).json(event);
 });

--- a/src/domains/issue/controller/issue.controller.ts
+++ b/src/domains/issue/controller/issue.controller.ts
@@ -37,15 +37,15 @@ issueRouter.post('/pm/:userId/project/:projectId', validateRequest(UserProjectPa
   return res.status(HttpStatus.OK).json(issues);
 });
 
-issueRouter.get('/:issueId/pause', validateRequest(IssuePauseParams, 'params'), async (_req: Request<IssuePauseParams>, res: Response) => {
+issueRouter.post('/:issueId/pause', validateRequest(IssuePauseParams, 'params'), async (_req: Request<IssuePauseParams>, res: Response) => {
   const { issueId } = _req.params;
 
   const event = await issueService.pauseTimer(issueId);
 
-  return res.status(HttpStatus.OK).json(event);
+  return res.status(HttpStatus.CREATED).json(event);
 });
 
-issueRouter.post('/:issueId/resume', async (_req: Request<IssuePauseParams>, res: Response) => {
+issueRouter.post('/:issueId/resume', validateRequest(IssuePauseParams, 'params'), async (_req: Request<IssuePauseParams>, res: Response) => {
   const { issueId } = _req.params;
 
   const event = await issueService.resumeTimer(issueId);

--- a/src/domains/issue/service/issue.service.ts
+++ b/src/domains/issue/service/issue.service.ts
@@ -3,6 +3,7 @@ import { type DevIssueFilterParameters, type IssueViewDTO, type PMIssueFilterPar
 
 export interface IssueService {
   pauseTimer: (issueId: string) => Promise<TimeTrackingDTO>;
+  resumeTimer: (issueId: string) => Promise<TimeTrackingDTO>;
   getIssueWorkedSeconds: (issueId: string) => Promise<WorkedTimeDTO>;
   getDevIssuesFilteredAndPaginated: (filters: DevIssueFilterParameters) => Promise<IssueViewDTO[]>;
   getIssuesFilteredAndPaginated: (filters: PMIssueFilterParameters) => Promise<IssueViewDTO[]>;

--- a/src/domains/projectStage/repository/projectStage.repository.impl.ts
+++ b/src/domains/projectStage/repository/projectStage.repository.impl.ts
@@ -14,6 +14,28 @@ export class ProjectStageRepositoryImpl implements ProjectStageRepository {
         type: input.type,
       },
     });
+
     return new ProjectStageDTO(projectStage);
+  }
+
+  /**
+   * Retrieves a project stage by project ID and stage ID.
+   *
+   * @param {Object} input - The input object containing project ID and stage ID.
+   * @param {string} input.projectId - The ID of the project.
+   * @param {string} input.stageId - The ID of the stage.
+   * @returns {Promise<ProjectStageDTO | null>} A promise that resolves to the project stage DTO if found, otherwise null.
+   */
+  async getByProjectIdAndStageId(input: { projectId: string; stageId: string }): Promise<ProjectStageDTO | null> {
+    const projectStage: ProjectStage | null = await this.db.projectStage.findUnique({
+      where: {
+        stageId_projectId: {
+          projectId: input.projectId,
+          stageId: input.stageId,
+        },
+      },
+    });
+
+    return projectStage != null ? new ProjectStageDTO(projectStage) : null;
   }
 }

--- a/src/domains/projectStage/repository/projectStage.repository.ts
+++ b/src/domains/projectStage/repository/projectStage.repository.ts
@@ -2,4 +2,5 @@ import { type ProjectStageCreationInput, type ProjectStageDTO } from '@domains/p
 
 export interface ProjectStageRepository {
   create: (input: ProjectStageCreationInput) => Promise<ProjectStageDTO>;
+  getByProjectIdAndStageId: (input: { projectId: string; stageId: string }) => Promise<ProjectStageDTO | null>;
 }

--- a/tests/domains/issue/issue.service.impl.test.ts
+++ b/tests/domains/issue/issue.service.impl.test.ts
@@ -1,15 +1,30 @@
 import { type IssueService, IssueServiceImpl } from '@domains/issue/service';
-import { issueRepositoryMock, eventRepositoryMock, userRepositoryMock, projectRepositoryMock } from './mock';
+import { issueRepositoryMock, eventRepositoryMock, userRepositoryMock, projectRepositoryMock, projectStageRepositoryMock } from './mock';
 import { ConflictException, NotFoundException } from '@utils';
-import { mockIssueDTO, stoppedMockTimeTrackingDTO, validMockManualTimeModification, invalidMockTimeTrackingDTO, mockUserDTO, mockProjectDTO, mockIssueViewDTO, mockIssueFilterParameters, mockNotRegisteredUserDTO } from './mockData';
+import {
+  mockIssueDTO,
+  stoppedMockTimeTrackingDTO,
+  validMockManualTimeModification,
+  invalidMockTimeTrackingDTO,
+  mockUserDTO,
+  mockProjectDTO,
+  mockIssueViewDTO,
+  mockIssueFilterParameters,
+  mockNotRegisteredUserDTO,
+  validMockTimeTrackingDTO,
+  mockIssueDTOWithoutStage,
+  mockProjectStageDTO,
+  mockProjectStageDTOStarted,
+} from './mockData';
 import { type IssueViewDTO, type WorkedTimeDTO } from '@domains/issue/dto';
+import { type TimeTrackingDTO } from '@domains/event/dto';
 
 describe('issue service tests', () => {
   let issueService: IssueService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    issueService = new IssueServiceImpl(issueRepositoryMock, eventRepositoryMock, userRepositoryMock, projectRepositoryMock);
+    issueService = new IssueServiceImpl(issueRepositoryMock, eventRepositoryMock, userRepositoryMock, projectRepositoryMock, projectStageRepositoryMock);
   });
 
   describe('pause method', () => {
@@ -159,6 +174,109 @@ describe('issue service tests', () => {
       expect.assertions(2);
       await expect(issueService.getDevIssuesFilteredAndPaginated({ ...mockIssueFilterParameters, projectId: wrongProjectId })).rejects.toThrow(NotFoundException);
       await expect(issueService.getDevIssuesFilteredAndPaginated({ ...mockIssueFilterParameters, projectId: wrongProjectId })).rejects.toThrow("Not found. Couldn't find Project");
+    });
+  });
+
+  describe('resumeTimer method', () => {
+    it('should throw NotFoundException if issue does not exist', async () => {
+      // given
+      const issueId = 'nonexistentIssueId';
+      issueRepositoryMock.getById.mockResolvedValue(null);
+
+      // when
+      const result = issueService.resumeTimer(issueId);
+
+      // then
+      await expect(result).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException if issue does not have stage', async () => {
+      // given
+      const issueId = mockIssueDTOWithoutStage.id;
+      issueRepositoryMock.getById.mockResolvedValue(mockIssueDTOWithoutStage);
+
+      // when
+      const result = issueService.resumeTimer(issueId);
+
+      // then
+      await expect(result).rejects.toThrow(ConflictException);
+      await expect(result).rejects.toThrow('This issue needs to be started in order to be able to track time');
+    });
+
+    it('should throw ConflictException if issue stage is not started type', async () => {
+      // given
+      const issueId = 'issueId';
+      issueRepositoryMock.getById.mockResolvedValue(mockIssueDTO);
+      projectStageRepositoryMock.getByProjectIdAndStageId.mockResolvedValue(mockProjectStageDTO);
+
+      // when
+      const result = issueService.resumeTimer(issueId);
+
+      // then
+      await expect(result).rejects.toThrow(ConflictException);
+      await expect(result).rejects.toThrow('This issue needs to be started in order to be able to track time');
+    });
+
+    it('should throw ConflictException if issue is already tracking time', async () => {
+      // given
+      const issueId = 'issueId';
+      issueRepositoryMock.getById.mockResolvedValue(mockIssueDTO);
+      projectStageRepositoryMock.getByProjectIdAndStageId.mockResolvedValue(mockProjectStageDTOStarted);
+      eventRepositoryMock.getLastTimeTrackingEvent.mockResolvedValue(validMockTimeTrackingDTO);
+
+      const result = issueService.resumeTimer(issueId);
+
+      // then
+      await expect(result).rejects.toThrow(ConflictException);
+      await expect(result).rejects.toThrow('This issue is already tracking time');
+    });
+
+    it('should return TimeTrackingDTO if issue has never tracked time', async () => {
+      // given
+      const issueId = 'issueId';
+      issueRepositoryMock.getById.mockResolvedValue(mockIssueDTO);
+      projectStageRepositoryMock.getByProjectIdAndStageId.mockResolvedValue(mockProjectStageDTOStarted);
+      eventRepositoryMock.getLastTimeTrackingEvent.mockResolvedValue(null);
+      const validEvent: TimeTrackingDTO = {
+        id: 'eventId',
+        issueId: mockIssueDTO.id,
+        startTime: new Date(),
+        endTime: null,
+      };
+      eventRepositoryMock.createTimeTrackingEvent.mockResolvedValue(validEvent);
+
+      // when
+      const result = await issueService.resumeTimer(issueId);
+
+      // then
+      expect(result).toBe(validEvent);
+    });
+
+    it('should return TimeTrackingDTO if issue is legally resumed', async () => {
+      // given
+      const issueId = 'issueId';
+      issueRepositoryMock.getById.mockResolvedValue(mockIssueDTO);
+      projectStageRepositoryMock.getByProjectIdAndStageId.mockResolvedValue(mockProjectStageDTOStarted);
+      const validEvent: TimeTrackingDTO = {
+        id: 'eventId',
+        issueId: mockIssueDTO.id,
+        startTime: new Date(),
+        endTime: new Date(),
+      };
+      eventRepositoryMock.getLastTimeTrackingEvent.mockResolvedValue(validEvent);
+      const newValidEvent: TimeTrackingDTO = {
+        id: 'newEventId',
+        issueId: mockIssueDTO.id,
+        startTime: new Date(),
+        endTime: null,
+      };
+      eventRepositoryMock.createTimeTrackingEvent.mockResolvedValue(newValidEvent);
+
+      // when
+      const result = await issueService.resumeTimer(issueId);
+
+      // then
+      expect(result).toBe(newValidEvent);
     });
   });
 });

--- a/tests/domains/issue/mock.ts
+++ b/tests/domains/issue/mock.ts
@@ -3,8 +3,10 @@ import { type IssueRepository } from '@domains/issue/repository';
 import { type EventRepository } from '@domains/event/repository';
 import { type UserRepository } from '@domains/user';
 import { type ProjectRepository } from '@domains/project/repository';
+import { type ProjectStageRepository } from '@domains/projectStage/repository';
 
 export const issueRepositoryMock: MockProxy<IssueRepository> = mock<IssueRepository>();
 export const eventRepositoryMock: MockProxy<EventRepository> = mock<EventRepository>();
 export const userRepositoryMock: MockProxy<UserRepository> = mock<UserRepository>();
 export const projectRepositoryMock: MockProxy<ProjectRepository> = mock<ProjectRepository>();
+export const projectStageRepositoryMock: MockProxy<ProjectStageRepository> = mock<ProjectStageRepository>();

--- a/tests/domains/issue/mockData.ts
+++ b/tests/domains/issue/mockData.ts
@@ -3,6 +3,7 @@ import { type ManualTimeModificationDTO, type TimeTrackingDTO } from '@domains/e
 import { type UserDTO } from '@domains/user';
 import { type ProjectDTO } from '@domains/project/dto';
 import { StageType } from '@prisma/client';
+import { type ProjectStageDTO } from '@domains/projectStage/dto';
 
 export const mockIssueDTO: IssueDTO = {
   assigneeId: 'user123',
@@ -19,6 +20,19 @@ export const mockIssueDTO: IssueDTO = {
   stageId: 'stage789',
   title: 'Sample Issue Title',
 };
+
+export const mockIssueDTOWithoutStage: IssueDTO = { ...mockIssueDTO, stageId: null };
+
+export const mockProjectStageDTO: ProjectStageDTO = {
+  id: 'd0725f8b-3823-4c6c-a2b8-9bd828f8b61c',
+  projectId: '28b8f326-6a73-4f0e-b625-b1f54f900e0a',
+  stageId: '83e8df95-7e75-4dde-aea1-280e144ada0e',
+  type: 'UNSTARTED',
+  createdAt: new Date(),
+  deletedAt: null,
+};
+
+export const mockProjectStageDTOStarted: ProjectStageDTO = { ...mockProjectStageDTO, type: 'STARTED' };
 
 export const invalidMockTimeTrackingDTO: TimeTrackingDTO = {
   issueId: 'issue789',


### PR DESCRIPTION
# Pull Request

## Description
Same as pause method, but with this once the timer can be resumed.

## Ticket Link
[TRI-143](https://linear.app/tricker-sirius/issue/TRI-143/implement-resume-ticket-method)

## Steps to Reproduce
1. Run `prisma generate`
2. Run `docker compose up`
3. Check Swagger documentation for [resume endpoint](http://localhost:8080/api-docs/#/Issue/get_api_issue__issueId__resume)
4. Test the endpoint with Postman or Swagger.